### PR TITLE
MEN-26 Mongo integration: configuration scripts and connections test

### DIFF
--- a/menelaos-backend/mongo/configure-db.js
+++ b/menelaos-backend/mongo/configure-db.js
@@ -1,0 +1,29 @@
+load('mock-parties.js');
+
+var db = connect('127.0.0.1:27017/admin');
+
+//user that can do anything in mongo
+db.createUser({
+    user:adminUsername,
+    pwd:adminPassword,
+		roles: [
+				{ role: "userAdminAnyDatabase", db: "admin" },
+				{ role: "readWriteAnyDatabase", db: "admin" },
+				{ role: "dbAdminAnyDatabase", db: "admin" },
+				{ role: "clusterAdmin", db: "admin" }
+			]
+});
+
+db = connect('127.0.0.1:27017/menelaosDB');
+
+//user for menelaosDB database
+db.createUser({
+	user:menelaosPassword,
+	pwd:menelaosUsername,
+	roles: [
+		{ role: "readWrite", db: "menelaosDB" }
+	]
+});
+
+db.createCollection('parties');
+db.createCollection('users');

--- a/menelaos-backend/mongo/configure-fill-db.sh
+++ b/menelaos-backend/mongo/configure-fill-db.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#this script:
+# - creates admin-super-user, normal-user and fills db with mock data
+# - leaves mongod service in authentication required mode
+
+#before running:
+# - ensure mongod service is down
+
+#start without auth to configure db
+sudo mongod --dbpath /var/lib/mongodb --fork --logpath /var/log/mongod.log
+
+mongo < configure-db.js
+
+sudo mongod --dbpath /var/lib/mongodb --shutdown
+
+#start with auth
+sudo mongod --dbpath /var/lib/mongodb --auth --fork --logpath /var/log/mongod.log
+
+mongo < fill-db.js

--- a/menelaos-backend/mongo/fill-db.js
+++ b/menelaos-backend/mongo/fill-db.js
@@ -1,0 +1,15 @@
+load('mock-parties.js');
+
+var menelaosDB = connect('127.0.0.1:27017/menelaosDB');
+
+menelaosDB.auth(menelaosUsername, menelaosPassword);
+
+for (idx in mockParties) {
+	var doc = mockParties[idx];
+	menelaosDB.parties.insert(doc);
+}
+
+for (idx in mockUsers) {
+	var doc = mockUsers[idx];
+	menelaosDB.users.insert(doc);
+}

--- a/menelaos-backend/mongo/mock-parties.js
+++ b/menelaos-backend/mongo/mock-parties.js
@@ -1,0 +1,77 @@
+var adminUsername='admin';
+var adminPassword='admin';
+
+var menelaosUsername='mendev';
+var menelaosPassword='mendev';
+
+// to authenticate, paste the following to the mongo shell after running the configuration script:
+// $ db.auth('admin','admin')
+// make sure you use db corresponding to authenticating user
+
+var mockParties =
+[
+	{
+		"_id" : ObjectId("5c48daea4109ab902700c911"),
+		"userId": ObjectId("9ab902704109ab902700c911"),
+		"partyName": "Urodziny Krzyśka",
+		"date": ISODate("2003-05-13T20:00:09Z"),
+		"description": "najebaem sie z marcinem i wojtkiem",
+		"partyEntries": [
+			{
+				"alcoholName": "beer",
+				"volumeKind": "BUTELKA_500",
+				"quantity": 3,
+				"date": ISODate("2003-05-13T20:23:34Z")
+			},
+			{
+				"alcoholName": "vodka",
+				"volumeKind": "KIELISZEK_50",
+				"quantity": 6,
+				"date": ISODate("2003-05-13T22:12:24Z")
+			}
+		]
+	},
+	{
+		"_id" : ObjectId("5c48daea4109ab902700c912"),
+		"userId": ObjectId("9ab902704109ab902700c911"),
+		"partyName": "Impreza Kaftu - Jagiellonska",
+		"date": ISODate("2019-01-25T16:30:32Z"),
+		"description": "dywanu nie bylo ale byly muzea",
+		"partyEntries": [
+			{
+				"alcoholName": "vodka",
+				"volumeKind": "MALPKA_200",
+				"quantity": 1,
+				"date": ISODate("2019-01-25T17:03:18Z")
+			},
+			{
+				"alcoholName": "beer",
+				"volumeKind": "BUTELKA_500",
+				"quantity": 1,
+				"date": ISODate("2019-01-25T18:50:10Z")
+			},
+			{
+				"alcoholName": "russian_champagne",
+				"volumeKind": "BUTELKA_700",
+				"quantity": 1,
+				"date": ISODate("2019-01-25T20:00:05Z")
+			}
+		]
+	}
+];
+
+
+var mockUsers =
+[
+	{
+		"_id" : ObjectId("9ab902704109ab902700c911"),
+		"email": "krzysiek@email.com",
+		"password": "abc123",
+		"firstName": "Krzysztof",
+		"lastName": "Mumbach",
+		"joinDate": ISODate("2008-05-13T20:00:09Z"),
+		"weight": 93,
+		"age": 29,
+		"gender": "MALE"
+	}
+];

--- a/menelaos-backend/src/main/resources/application.properties
+++ b/menelaos-backend/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.data.mongodb.host = localhost
+spring.data.mongodb.port = 27017
+spring.data.mongodb.database = menelaosDB
+spring.data.mongodb.username = mendev
+spring.data.mongodb.password = mendev


### PR DESCRIPTION
Main feature of this improvement is the `mongo` folder. Script `configure-fill-db.sh`  is supposed to be ran by a developer (*.js script are called from the inside of sh script).

JUnit Tests provided don't require insertion of mock data from scripts, but they do require configuration steps (creating users, collections etc) included in those scripts.

repositories in /dao and dtos in /dto are structured according to scheme from OneNote (Architektura Aplikacji -> Struktura backendu) 